### PR TITLE
conditionally call setState on mouse move

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -646,15 +646,22 @@ export default class ReactCalendarTimeline extends Component {
     return time
   }
 
-  dragItem = (item, dragTime, newGroupOrder) => {
-    let newGroup = this.props.groups[newGroupOrder]
+  dragItem = (draggingItem, dragTime, newGroupOrder) => {
+    const newGroup = this.props.groups[newGroupOrder]
     const keys = this.props.keys
 
+    const dragGroupTitle = newGroup ? _get(newGroup, keys.groupTitleKey) : ''
+
+    if (this.state.dragTime === dragTime
+      && this.state.draggingItem === draggingItem
+      && this.state.newGroupOrder === newGroupOrder
+      && this.state.dragGroupTitle === dragGroupTitle) return; // nothing has changed, do not mutate state
+
     this.setState({
-      draggingItem: item,
-      dragTime: dragTime,
-      newGroupOrder: newGroupOrder,
-      dragGroupTitle: newGroup ? _get(newGroup, keys.groupTitleKey) : ''
+      draggingItem,
+      dragTime,
+      newGroupOrder,
+      dragGroupTitle
     })
   }
 


### PR DESCRIPTION
`setState` is called for every mouse event. This commit adds a check, so if the state is not about to mutate, then `setState` is not called.

This should improve performance, because re-rendering the entire control on every mouse move is expensive for calendars with a large number of items.