### PR TITLE
setting state in Timeline.js on start of interactions

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1069,7 +1069,7 @@ export default class ReactCalendarTimeline extends Component {
                 traditionalZoom={traditionalZoom}
                 onScroll={this.onScroll}
                 isInteractingWithItem={isInteractingWithItem}
-                isItemSelected={this.state.selectedItem && true}
+                isItemSelected={!!this.state.selectedItem}
               >
               <MarkerCanvas>
                   {this.items(

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1069,6 +1069,7 @@ export default class ReactCalendarTimeline extends Component {
                 traditionalZoom={traditionalZoom}
                 onScroll={this.onScroll}
                 isInteractingWithItem={isInteractingWithItem}
+                isItemSelected={this.state.selectedItem && true}
               >
               <MarkerCanvas>
                   {this.items(

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -242,6 +242,14 @@ export default class Item extends Component {
             dragTime: this.itemTimeStart,
             dragGroupDelta: 0
           })
+          if (this.props.onDrag) {
+            this.props.onDrag(
+              this.itemId,
+              this.itemTimeStart,
+              this.props.order.index,
+              this.props.item
+            )
+          }
         } else {
           return false
         }
@@ -335,6 +343,10 @@ export default class Item extends Component {
             resizeStart: e.pageX,
             resizeTime: 0
           })
+
+          if (this.props.onResizing) {
+            this.props.onResizing(this.itemId, 0, null)
+          }
         } else {
           return false
         }

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -10,6 +10,7 @@ class ScrollElement extends Component {
     traditionalZoom: PropTypes.bool.isRequired,
     scrollRef: PropTypes.func.isRequired,
     isInteractingWithItem: PropTypes.bool.isRequired,
+    isItemSelected: PropTypes.bool.isRequired,
     onZoom: PropTypes.func.isRequired,
     onWheelZoom: PropTypes.func.isRequired,
     onScroll: PropTypes.func.isRequired
@@ -18,8 +19,10 @@ class ScrollElement extends Component {
   constructor() {
     super()
     this.state = {
-      isDragging: false
+      isDragging: false,
+      startDragMs: null,
     }
+    this.dragDelayMs = 250; // 250 ms delay
   }
 
   componentDidMount(){
@@ -60,20 +63,28 @@ class ScrollElement extends Component {
     if(this.props.isInteractingWithItem) {
       return;
     }
-    
+
     if (e.button === 0) {
       this.dragStartPosition = e.pageX
       this.dragLastPosition = e.pageX
       this.setState({
-        isDragging: true
+        isDragging: true,
+        startDragMs: (new Date()).valueOf(),
       })
     }
   }
 
   handleMouseMove = e => {
-    // this.props.onMouseMove(e)
     //why is interacting with item important?
     if (this.state.isDragging && !this.props.isInteractingWithItem) {
+      if (this.props.itemSelected) {
+        const msNow = (new Date()).valueOf();
+        const elapsedMs = msNow - this.state.startDragMs;
+        if(elapsedMs < this.dragDelayMs) {
+          return;
+        }
+      }
+
       this.scrollComponent.scrollLeft += this.dragLastPosition - e.pageX
       this.dragLastPosition = e.pageX
     }
@@ -84,7 +95,8 @@ class ScrollElement extends Component {
     this.dragLastPosition = null
 
     this.setState({
-      isDragging: false
+      isDragging: false,
+      startDragMs: null,
     })
   }
 
@@ -93,7 +105,8 @@ class ScrollElement extends Component {
     this.dragStartPosition = null
     this.dragLastPosition = null
     this.setState({
-      isDragging: false
+      isDragging: false,
+      startDragMs: null,
     })
   }
 

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -57,6 +57,10 @@ class ScrollElement extends Component {
   }
 
   handleMouseDown = e => {
+    if(this.props.isInteractingWithItem) {
+      return;
+    }
+    
     if (e.button === 0) {
       this.dragStartPosition = e.pageX
       this.dragLastPosition = e.pageX

--- a/src/lib/scroll/ScrollElement.js
+++ b/src/lib/scroll/ScrollElement.js
@@ -22,7 +22,7 @@ class ScrollElement extends Component {
       isDragging: false,
       startDragMs: null,
     }
-    this.dragDelayMs = 250; // 250 ms delay
+    this.dragDelayMs = 500; // 500 ms delay
   }
 
   componentDidMount(){
@@ -77,7 +77,7 @@ class ScrollElement extends Component {
   handleMouseMove = e => {
     //why is interacting with item important?
     if (this.state.isDragging && !this.props.isInteractingWithItem) {
-      if (this.props.itemSelected) {
+      if (this.props.isItemSelected) {
         const msNow = (new Date()).valueOf();
         const elapsedMs = msNow - this.state.startDragMs;
         if(elapsedMs < this.dragDelayMs) {


### PR DESCRIPTION
Delaying the drag action by 500ms when an item is selected until the state has time to change.

**Issue Number**
[TACW-3026](https://geoplex.jira.com/browse/TACW-3026)
[Affects TACW-2685](https://geoplex.jira.com/browse/TACW-2685)

**Overview of PR**
Hack to make the canvas drag delayed when an item is selected on timeline.